### PR TITLE
WL-3802 Include the sort property.

### DIFF
--- a/utils/src/java/org/sakaiproject/entitybroker/util/EntityDataUtils.java
+++ b/utils/src/java/org/sakaiproject/entitybroker/util/EntityDataUtils.java
@@ -71,7 +71,6 @@ public class EntityDataUtils {
 			add(ResourceProperties.PROP_CONTENT_TYPE);
 			add(ResourceProperties.PROP_CONTENT_PRIORITY);
 			add(ResourceProperties.PROP_CONTENT_LENGTH);
-			add(ResourceProperties.PROP_HAS_CUSTOM_SORT);
 			add(ResourceProperties.PROP_IS_COLLECTION);
 		}
 	});


### PR DESCRIPTION
This is so that the BSG app can know which folders should be sorted by using the priority values of the resources.
